### PR TITLE
chore: improve devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:bullseye
+
+RUN curl -sL https://github.com/gohugoio/hugo/releases/download/v0.126.1/hugo_extended_0.126.1_linux-amd64.deb --output /tmp/hugo.deb \
+    && echo "bbaf0cb1de758f4fee4501fff9fd20ec632ec4cc25b7c1c6a916d538acc4715f  /tmp/hugo.deb" | sha256sum -c - \
+    && sudo apt install /tmp/hugo.deb \
+    && rm /tmp/hugo.deb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,9 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-    "name": "Go",
-    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    "image": "mcr.microsoft.com/devcontainers/go:1-1.22-bullseye",
-    "features": {
-        "ghcr.io/devcontainers/features/node:1": {
-            "nodeGypDependencies": true,
-            "version": "lts",
-            "nvmVersion": "latest"
-        }
-    },
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
 {
 	"name": "Debian",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},
@@ -12,7 +14,7 @@
     // "forwardPorts": [],
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "sh ./.devcontainer/postCreate.sh"
+    // "postCreateCommand": "sh ./.devcontainer/postCreate.sh",
 
     // Configure tool-specific properties.
     // "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "build": {
         "dockerfile": "Dockerfile"
-    }
+    },
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},
@@ -17,7 +17,13 @@
     // "postCreateCommand": "sh ./.devcontainer/postCreate.sh",
 
     // Configure tool-specific properties.
-    // "customizations": {},
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens"
+            ]
+        }
+    }
 
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"

--- a/.devcontainer/hugo_checksums.txt
+++ b/.devcontainer/hugo_checksums.txt
@@ -1,1 +1,0 @@
-bbaf0cb1de758f4fee4501fff9fd20ec632ec4cc25b7c1c6a916d538acc4715f  /tmp/hugo.deb

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,4 +1,0 @@
-curl -sL https://github.com/gohugoio/hugo/releases/download/v0.126.1/hugo_extended_0.126.1_linux-amd64.deb --output /tmp/hugo.deb \
-    && grep hugo.deb ./.devcontainer/hugo_checksums.txt | sha256sum -c - \
-    && sudo apt install /tmp/hugo.deb \
-    && rm /tmp/hugo.deb

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ git submodule update --remote --merge
 To update Hugo version (for vscode devcontainer workflow):
 
 1. Go to [Hugo GitHub Releases page](https://github.com/gohugoio/hugo/releases) and find the specific version needed.
-    - Copy the URL to the AMD64 `.deb` file there, and update your `./.devcontainer/postCreate.sh` accordingly.
-    - Open the `*_checksums.txt` there, and update your `./.devcontainer/hugo_checksums.txt` with the SHA256 checksum (without changing the file path).
+    - Copy the URL to the AMD64 `.deb` file there, and update your `./.devcontainer/Dockerfile` accordingly.
+    - Open the `*_checksums.txt` there, and update your `./.devcontainer/Dockerfile` with the SHA256 checksum (without changing the file path).
 2. In VS Code, open Command Palette (F1), run "Dev Containers: Rebuild Container".

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,3 +2,15 @@ baseURL: https://MachHach.github.io/blog/
 languageCode: en-us
 title: Henry Koh
 theme: PaperMod
+
+minify:
+  disableXML: true
+  minifyOutput: true
+
+params:
+  ShowReadingTime: true
+  disableScrollToTop: false
+  socialIcons:
+    - name: github
+      title: View Source on Github
+      url: "https://github.com/MachHach/blog"


### PR DESCRIPTION
Changes
- reduce build size via `minifyOutput`
- show reading time of posts
- show social icons in home page (not working but will add it in for now)
- omit unneeded Go and Node dependencies in devcontainer environment
- improve Docker build and postCreate of devcontainer environment via cache-able layers of `Dockerfile`
- pre-installed GitLens extension in devcontainer environment
